### PR TITLE
Fixed a few links on the features index

### DIFF
--- a/features/index.html
+++ b/features/index.html
@@ -57,7 +57,7 @@ to work, and are supported via the <a href="/list/users.html">users
 list</a>.  We suggest that the server be installed via a <a
 href="os.html">pre-built package</a> if one is available.  If a
 package does not exist for your system, it can be built from <a
-href="download.html">source</a>.</p>
+href="/download.html">source</a>.</p>
 
 <h2>AAA Functionality</h2>
 
@@ -77,9 +77,8 @@ and Vista, Linux, Mac OSX, *BSD, and many others.</p>
 href="post-auth.html">post-authentication</a> <a
 href="policy.html">policies</a> are supported.  Polices may be stored
 in <a href="databases.html">databases</a>, flat-text files, or in <a
-href="http://wiki.freeradius.org/Rlm_perl">Perl</a>, <a
-href="http://wiki.freeradius.org/Rlm_java">Java</a> or <a
-href="http://wiki.freeradius.org/Rlm_python">Python</a> scripts.</p>
+href="http://wiki.freeradius.org/modules/Rlm_perl">Perl</a> or <a
+href="http://wiki.freeradius.org/modules/Rlm_python">Python</a> scripts.</p>
 
 <p>IP addresses can be allocated through <a href="ippool.html">IP
 Pools</a>.</p>


### PR DESCRIPTION
The link to rlm_java has been removed completely. The only reference to java (http://wiki.freeradius.org/modules/Rlm_jradius) says it only lives in CVS head (FreeRADIUS 2.0). To me it looks a bit like that project has been abandoned.
