### PR TITLE
Improves #7: Fix typo, and discourage use of EAP-TNC

### DIFF
--- a/features/eap.html
+++ b/features/eap.html
@@ -78,7 +78,7 @@ authentication.</p>
 <li>EAP-SAKE<sup><a href="#note-1">1</a></sup></li>
 <li>EAP-TLS<sup><a href="#note-2">2</a></sup></li>
 </ul>
-<li>EAP-TNC<sup><a href="#note-2">2</a></sup></li>
+<li>EAP-TNC<sup><a href="#note-2">2</a></sup> (use is discouraged)</li>
 </ul>
 
 <p>The following methods are also supported, but cannot be used with
@@ -105,7 +105,7 @@ using the native FreeRADIUS EAP implementation.</p>
 
 <p><sup><a name="note-3">3</a></sup> &nbsp; Supported via the "eap" module with
 FreeRADIUS 3.0 and later. In FreeRADIUS >= 2.0 < 3.0 both the "eap" and "eap2"
-could beused but some of their functionality may have been different between the
+could be, used but some of their functionality may have been different between the
 two implementations. See their configuration files for more details.</p>
 
 


### PR DESCRIPTION
Alan DeKok wrote on the lists: "EAP-TNC should probably be deleted"

Since it hasn't been removed as of writing, discourage its use.