### PR TITLE
Link fixes to git.freeradius.org

### DIFF
--- a/development.html
+++ b/development.html
@@ -39,8 +39,8 @@
     <p>Development of FreeRADIUS is done
     using <a href="https://github.com/FreeRADIUS/freeradius-server/">Github.</a>
     Please submit issues, bugs, patches, etc. there.  Additional
-    instructions are on <a href="http://git.freeradius.org">our git
-    page</a>.</p>
+    instructions are on <a href="http://wiki.freeradius.org/contributing/GitHub">
+    the wiki</a>.</p>
 
     <p>The FTP site contains some additional patches that are
     specialized and haven't been applied to the tree.</p>

--- a/download.html
+++ b/download.html
@@ -119,7 +119,7 @@ Solaris,
 
 <h1>Checking out from source control</h1>
 
-<p>See <a href="http://git.freeradius.org">git.freeradius.org</a> for
+<p>See <a href="https://github.com/FreeRADIUS/freeradius-server">https://github.com/FreeRADIUS/freeradius-server</a> for
 the new "git" tree of the FreeRADIUS server.  The other projects are
 still accessible via the <a href="development.html#cvs">CVS
 instruction</a> page.</p>

--- a/git/commit.html
+++ b/git/commit.html
@@ -27,7 +27,7 @@ access to the main git tree.</p>
 for anonymous access:</p>
 
 <pre class="config">
-$ git clone git@git.freeradius.org:freeradius-server.git <em>radiusd</em>
+$ git clone https://github.com/FreeRADIUS/freeradius-server.git <em>radiusd</em>
 </pre>
 
 <p>Where <tt><em>radiusd</em></tt> is the local directory which will

--- a/git/howto.html
+++ b/git/howto.html
@@ -39,7 +39,7 @@ any local changes are lost.</p>
 <p>The solution is the following work flow:</p>
 
 <pre class="config">
-$ git clone git://git.freeradius.org/freeradius-server.git radiusd
+$ git clone https://github.com/FreeRADIUS/freeradius-server.git radiusd
 $ cd radiusd
 $ git checkout -b local
 </pre>

--- a/git/index.html
+++ b/git/index.html
@@ -67,16 +67,6 @@ $ make install
 <p>Please read the <a href="howto.html">howto</a> page for the
 suggested git work flow.</p>
 
-<h2>Repositories</h2>
-
-<p>The repositories available on this server are:</p>
-
-<ul>
-<li>git://git.freeradius.org/mod_auth_radius.git - The FreeRADIUS Apache Module for RADIUS Authentication</li>
-</ul>
-
-<p>These repositories are also available on <a href="http://github.com/FreeRADIUS/">github</a></p>
-
 <h2>Submitting Patches</h2>
 
 <p>See the <a href="patches.html">patch page</a> for instructions</p>

--- a/mirrors.html
+++ b/mirrors.html
@@ -52,7 +52,7 @@ href="ftp://ftp.us.freeradius.org/pub/radius/">ftp://ftp.us.freeradius.org/pub/r
 <p>New mirrors can be set up via:</p>
 
 <pre class="config">
-$ git clone git://git.freeradius.org/www.freeradius.org.git
+$ git clone https://github.com/FreeRADIUS/www.freeradius.org.git
 $ cd www.freeradius.org/.git/hooks
 $ chmod +x post-update
 $ vi post-update


### PR DESCRIPTION
Replaced them with links to github, where applicable.

The following links remain, they have no alternative on github or refer to directories rather than repositories.

```
doc/update.sh:MAN_FILES=$(find ../../git.freeradius.org/man/ -type f -print)
radiusd/man/Makefile:MAN    := ../../../git.freeradius.org/man
git/eapodhcp.html:$ git clone git://git.freeradius.org/hostap-06.git
git/eapodhcp.html:$ git clone git://git.freeradius.org/busybox.git
```
