### PR TITLE
New doc variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@ how the server works.</p>
 
 <p>There is extensive documentation for the server available via
 the <a href="http://networkradius.com/doc/<!--#echo
-var="freeradius3_version" -->/">Network RADIUS
+var="freeradius3_doc_version" -->/">Network RADIUS
 Documentation</a> page.  The "introduction" and "concepts" chapters
 are not available there yet, as those subjects are covered in the
 Technical guide.</p>

--- a/variables.html
+++ b/variables.html
@@ -2,6 +2,7 @@
 <!--#set var="freeradius_version" value="2.2.9" -->
 <!--#set var="freeradius_release" value="30 September 2015" -->
 <!--#set var="freeradius3_version" value="3.0.10" -->
+<!--#set var="freeradius3_doc_version" value="3.0.10" -->
 <!--#set var="freeradius3_release" value="05 October 2015" -->
 <!--#set var="freeradius1_major_version" value="1.1" -->
 <!--#set var="freeradius1_version" value="1.1.8" -->


### PR DESCRIPTION
Proposing a new doc version variable for the front page link. Self explanatory as the link seems to 404 on new releases.